### PR TITLE
fix: 修正巢狀 ZIP 解壓縮邏輯，保留內部目錄結構

### DIFF
--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -229,7 +229,7 @@ class TestSyncCNS11643(unittest.TestCase):
             self.assertEqual(result, '20250718')
 
     def test_extract_nested_zips(self):
-        """測試巢狀 ZIP 檔案解壓縮"""
+        """測試巢狀 ZIP 檔案解壓縮（保留 ZIP 內部目錄結構）"""
         import zipfile
         from sync_cns11643 import CNS11643Syncer
         from config import SyncConfig
@@ -240,10 +240,11 @@ class TestSyncCNS11643(unittest.TestCase):
             properties_dir.mkdir()
 
             # 建立模擬的 CNS_component_word.zip
+            # ZIP 內部已有 parts/ 目錄結構（與實際檔案結構相同）
             nested_zip_path = properties_dir / 'CNS_component_word.zip'
             with zipfile.ZipFile(nested_zip_path, 'w') as zf:
-                zf.writestr('test_part.png', b'fake png data')
-                zf.writestr('subdir/another.png', b'more data')
+                zf.writestr('parts/test_part.png', b'fake png data')
+                zf.writestr('parts/subdir/another.png', b'more data')
 
             config = SyncConfig()
             config.tables_path = tmppath
@@ -251,7 +252,7 @@ class TestSyncCNS11643(unittest.TestCase):
             syncer = CNS11643Syncer(config)
             syncer._extract_nested_zips(properties_dir)
 
-            # 驗證解壓縮結果
+            # 驗證解壓縮結果（ZIP 內的 parts/ 目錄被保留）
             parts_dir = properties_dir / 'parts'
             self.assertTrue(parts_dir.is_dir())
             self.assertTrue((parts_dir / 'test_part.png').exists())


### PR DESCRIPTION
## Summary

修正 `CNS_component_word.zip` 解壓縮邏輯錯誤。

**問題**：ZIP 內部已有 `parts/` 目錄結構，但程式碼又額外建立 `parts/` 目錄，導致檔案解壓縮到錯誤位置。

**修正**：
- 新增 `_extract_nested_zip_preserve_structure` 方法
- 直接解壓縮到 `Properties/`，保留 ZIP 內部的 `parts/` 目錄結構
- 更新測試以匹配實際 ZIP 結構

## Test plan

- [x] 14 個測試全數通過
- [ ] 合併後觸發 workflow 驗證 parts/ 目錄正確建立

🤖 Generated with [Claude Code](https://claude.com/claude-code)